### PR TITLE
Fix spacing typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It's still in its extremely early stage, and even the goals/planned features are
 - [ ] Typeclasses/Traits and HKTs
 - [ ] Mutability restriction, mainly based on Rust rules (but I'm not sure if whether or not Kamai rules will be exactly the same as Rust's)
 
-Yes, Kamai is Rust with : currying, a built in GC and, probably, a locally space sensitive syntax. And I'll probably remove some things from this list and add new fancy features at some point, but for the moment that's how the list looks like. I'll try to update it as often as I think about it. 
+Yes, Kamai is Rust with: currying, a built in GC and, probably, a locally space sensitive syntax. And I'll probably remove some things from this list and add new fancy features at some point, but for the moment that's how the list looks like. I'll try to update it as often as I think about it. 
 
 ## Goals
 


### PR DESCRIPTION
# Introduction

As I believe in the greater good of the English language and the development of documentation as the foundation for a tremendous future, I decided to fix a small typo in your README.

# What does that mean?

In English, there is no space before a colon. This is a common mistake of French speakers since it is the case in their weird language. However, you might want to know that it is one of the unique characteristic of French typesetting. You can read more about this [here](https://en.wikipedia.org/wiki/Sentence_spacing).

# Why would you do this?

Each typo fixed saves another child in the world. It is a direct consequence of quantum physics and the butterfly effect. There's a great movie that talks about it where the main character goes back in time and changes little things and lives the consequences. It's called The Butterfly Effect.  

# Isn't this a useless PR?

You know, I don't believe we should bring philosophy in the discussion but I don't think we have a choice. Whether or not this PR is useful is highly subjective and nobody should be judged so harshly, so fast.  
What if, for example, the President Of The United States decided to use Kamaï to rediscover Computer Science.  
What if he decided that it would become the universal programming language. Right there, overnight.  
By morning, everyone on earth would read this README and notice this spacing error. They would think "Wow, that's not a native speaker!" and since they're American, nukes would be involved.  

# Conclusion

Think of the children. Think of the mothers. Think of your ancestors. All those people that brought you there to live what you want to live.  
Do you want to deceive all of humanity with a spacing error? I don't think you do. Therefore, I think you want to merge this PR.
Thank you.